### PR TITLE
Add support for include_ parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .ijwb
 bazel-*
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@ Test and report tool to validate classpath collision cases
         target = "foo",
         ignore_prefixes = ["example_prefix"], #optional
         ignore_suffixes = ["example_suffix"], #optional
+        include_prefixes = ["example_prefix"], #optional
+        include_suffixes = ["example_suffix"], #optional
     )
     ```
 3. Run `bazel test //path/to/package:test_classpath`
 
 ### How does the test work?
 * The test would inspect the different jar entries of any jar in runtime closure of given `target`
-* The test would ignore entries with given suffix or prefixes. 
+* The test would ignore entries with given prefixes or suffix and look only at entries that match the provided
+prefixes or suffixes (or all entries if the `include_prefix` and `include_suffixes` are not provided)
 * If same entry was found in two places with different content (digest based) the test would fail and a report would be emitted.
 
 
@@ -55,6 +58,9 @@ Found 1 collisions
 
 ```
 
+##ignore_ vs include_ parameters
+The test will perform the filtering out of all entries from JARs before looking at what to include, i.e.
+if an entry from a JAR matches both `ignore_` and `include_` pattern, then `ignore_` will take precedence.
 
 ## Default ignore list
 I allowed myself to add few default prefixes / suffixes to ignore.

--- a/classpath_validator.bzl
+++ b/classpath_validator.bzl
@@ -5,39 +5,30 @@ def _label_as_string(label):
         name = label.name,
     )
 
-def _write_entries_file(ctx, entry_list, file_name):
-    entries_file = ctx.actions.declare_file(file_name)
-    ctx.actions.write(
-        output = entries_file,
-        content = "\n".join(entry_list),
-    )
-    return entries_file
+def _construct_args(args, argument_name, values):
+    for value in values:
+        args.append(
+            '''"{0}={1}"'''.format(argument_name, value)
+        )
 
 def _impl(ctx):
     target = ctx.attr.target
     runtime_jars = target[java_common.provider].transitive_runtime_jars.to_list()
 
-    # write argument file
-    jars_file = ctx.actions.declare_file(ctx.label.name + "_jars.txt")
-    ctx.actions.write(
-        output = jars_file,
-        content = "\n".join([(_label_as_string(j.owner) + " " + j.short_path) for j in runtime_jars]),
-    )
+    jars = [(_label_as_string(j.owner) + " " + j.short_path) for j in runtime_jars]
 
-    ignore_prefixes_file = _write_entries_file(ctx, ctx.attr.ignore_prefixes, ctx.label.name + "_ignore_prefixes.txt")
-    ignore_suffixes_file = _write_entries_file(ctx, ctx.attr.ignore_suffixes, ctx.label.name + "_ignore_suffixes.txt")
-    include_prefixes_file = _write_entries_file(ctx, ctx.attr.include_prefixes, ctx.label.name + "_include_prefixes.txt")
-    include_suffixes_file = _write_entries_file(ctx, ctx.attr.include_suffixes, ctx.label.name + "_include_suffixes.txt")
+    arguments = []
+    _construct_args(arguments, "--ignore-prefix", ctx.attr.ignore_prefixes)
+    _construct_args(arguments, "--ignore-suffix", ctx.attr.ignore_suffixes)
+    _construct_args(arguments, "--include-prefix", ctx.attr.include_prefixes)
+    _construct_args(arguments, "--include-suffix", ctx.attr.include_suffixes)
+    _construct_args(arguments, "--jar-targets", jars)
 
     # generate executable command
     validator_exectuable = ctx.attr._validator[DefaultInfo].files_to_run.executable.short_path
-    cmd = "{validator_exectuable} {jar_files_path} {ignore_prefixes_file} {ignore_suffixes_file} {include_prefixes_file} {include_suffixes_file}".format(
+    cmd = "{validator_exectuable} {arguments}".format(
         validator_exectuable = validator_exectuable,
-        jar_files_path = jars_file.short_path,
-        ignore_prefixes_file = ignore_prefixes_file.short_path,
-        ignore_suffixes_file = ignore_suffixes_file.short_path,
-        include_prefixes_file = include_prefixes_file.short_path,
-        include_suffixes_file = include_suffixes_file.short_path,
+        arguments = " ".join(arguments),
     )
 
     exec = ctx.actions.declare_file(ctx.label.name + "_test_run.sh")
@@ -48,7 +39,7 @@ def _impl(ctx):
     )
 
     # compute runfiles
-    runfiles = ctx.runfiles(files = [exec, jars_file, ignore_prefixes_file, ignore_suffixes_file, include_prefixes_file, include_suffixes_file] + runtime_jars) \
+    runfiles = ctx.runfiles(files = [exec,] + runtime_jars) \
         .merge(ctx.attr._validator[DefaultInfo].default_runfiles)
 
     return [DefaultInfo(executable = exec, runfiles = runfiles)]

--- a/src/main/com/bazelbuild/java/classpath/ClasspathValidatorArguments.java
+++ b/src/main/com/bazelbuild/java/classpath/ClasspathValidatorArguments.java
@@ -1,0 +1,69 @@
+package com.bazelbuild.java.classpath;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ClasspathValidatorArguments {
+    private List<String> ignorePrefix = new ArrayList<>();
+    private List<String> ignoreSuffix = new ArrayList<>();
+    private List<String> includePrefix = new ArrayList<>();
+    private List<String> includeSuffix = new ArrayList<>();
+    private List<String> jarTargets = new ArrayList<>();
+
+    final private String JarTargets = "--jar-targets";
+    final private String IgnorePrefix = "--ignore-prefix";
+    final private String IgnoreSuffix = "--ignore-suffix";
+    final private String IncludePrefix = "--include-prefix";
+    final private String IncludeSuffix = "--include-suffix";
+
+    final private List<String> Arguments = Arrays.asList(
+        JarTargets, IgnorePrefix, IgnoreSuffix, IncludePrefix, IncludeSuffix
+    );
+
+    public ClasspathValidatorArguments(String[] args) {
+        List<String> arguments = Arrays.asList(args);
+
+        jarTargets = extractParameters(JarTargets, arguments);
+        ignorePrefix = extractParameters(IgnorePrefix, arguments);
+        ignoreSuffix = extractParameters(IgnoreSuffix, arguments);
+        includePrefix = extractParameters(IncludePrefix, arguments);
+        includeSuffix = extractParameters(IncludeSuffix, arguments);
+    }
+
+    private List<String> extractParameters(String parameterName, List<String> arguments) {
+        List<String> collectedValues = new ArrayList<>();
+
+        for (String arg : arguments) {
+            String prefix = String.format("%s=", parameterName);
+            if (arg.startsWith(prefix)) {
+                String parsedValue = arg.substring(prefix.length());
+                if (!parsedValue.isEmpty()) {
+                    collectedValues.add(parsedValue);
+                }
+            }
+        }
+
+        return collectedValues;
+    }
+
+    public List<String> getIgnorePrefix() {
+        return ignorePrefix;
+    }
+
+    public List<String> getIgnoreSuffix() {
+        return ignoreSuffix;
+    }
+
+    public List<String> getIncludePrefix() {
+        return includePrefix;
+    }
+
+    public List<String> getIncludeSuffix() {
+        return includeSuffix;
+    }
+
+    public List<String> getJarTargets() {
+        return jarTargets;
+    }
+}

--- a/src/main/com/bazelbuild/java/classpath/ClasspathValidatorArguments.java
+++ b/src/main/com/bazelbuild/java/classpath/ClasspathValidatorArguments.java
@@ -33,9 +33,9 @@ public class ClasspathValidatorArguments {
 
     private List<String> extractParameters(String parameterName, List<String> arguments) {
         List<String> collectedValues = new ArrayList<>();
+        String prefix = String.format("%s=", parameterName);
 
         for (String arg : arguments) {
-            String prefix = String.format("%s=", parameterName);
             if (arg.startsWith(prefix)) {
                 String parsedValue = arg.substring(prefix.length());
                 if (!parsedValue.isEmpty()) {

--- a/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
+++ b/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
@@ -18,7 +18,7 @@ public class ClasspathValidatorCli {
         List<String> labelsToJarsPaths = cliArgs.getJarTargets();
         List<String> ignorePrefixes = cliArgs.getIgnorePrefix();
         List<String> ignoreSuffixes = cliArgs.getIgnoreSuffix();
-        List<String> includePrefixes = cliArgs.getIncludeSuffix();
+        List<String> includePrefixes = cliArgs.getIncludePrefix();
         List<String> includeSuffixes = cliArgs.getIncludeSuffix();
 
         ClassPathValidator validator = new ClassPathValidator(ignorePrefixes, ignoreSuffixes, includePrefixes, includeSuffixes);

--- a/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
+++ b/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
@@ -13,15 +13,14 @@ public class ClasspathValidatorCli {
         System.out.println("Classpath Collision Finder");
         System.out.println("====================");
 
-        if (args.length < 5) {
-            throw new IllegalArgumentException("Usage: ClasspathValidatorCli <targets_to_jar_file> <ignore_prefixes_file> <ignore_suffixes_file> <include_prefixes_file> <include_suffixes_file>");
-        }
+        ClasspathValidatorArguments cliArgs = new ClasspathValidatorArguments(args);
 
-        List<String> labelsToJarsPaths = readInputLines(args[0]);
-        List<String> ignorePrefixes = readInputLines(args[1]);
-        List<String> ignoreSuffixes = readInputLines(args[2]);
-        List<String> includePrefixes = readInputLines(args[3]);
-        List<String> includeSuffixes = readInputLines(args[4]);
+        List<String> labelsToJarsPaths = cliArgs.getJarTargets();
+        List<String> ignorePrefixes = cliArgs.getIgnorePrefix();
+        List<String> ignoreSuffixes = cliArgs.getIgnoreSuffix();
+        List<String> includePrefixes = cliArgs.getIncludeSuffix();
+        List<String> includeSuffixes = cliArgs.getIncludeSuffix();
+
         ClassPathValidator validator = new ClassPathValidator(ignorePrefixes, ignoreSuffixes, includePrefixes, includeSuffixes);
         List<ClasspathValidatorJarInput> jars = labelsToJarsPaths.stream()
                 .map(ClasspathValidatorCli::toInput)
@@ -38,15 +37,6 @@ public class ClasspathValidatorCli {
         if (!collisions.isEmpty()) {
             throw new RuntimeException(exceptionCountPrint);
         }
-    }
-
-    private static List<String> readInputLines(String filePath) throws IOException {
-        Path targetsToJarsFile = asReadablePath(filePath);
-        return Files.readAllLines(targetsToJarsFile).stream()
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .filter(s -> !s.startsWith("#"))
-                .collect(Collectors.toList());
     }
 
     private static void printCollisions(List<ClasspathCollision> collisions) {

--- a/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
+++ b/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
@@ -12,13 +12,17 @@ public class ClasspathValidatorCli {
         System.out.println("====================");
         System.out.println("Classpath Collision Finder");
         System.out.println("====================");
-        if (args.length < 3) {
-            throw new IllegalArgumentException("Usage: ClasspathValidatorCli <targets_to_jar_file> <ignore_prefixes_file> <ignore_suffixes_file>");
+
+        if (args.length < 5) {
+            throw new IllegalArgumentException("Usage: ClasspathValidatorCli <targets_to_jar_file> <ignore_prefixes_file> <ignore_suffixes_file> <include_prefixes_file> <include_suffixes_file>");
         }
+
         List<String> labelsToJarsPaths = readInputLines(args[0]);
         List<String> ignorePrefixes = readInputLines(args[1]);
         List<String> ignoreSuffixes = readInputLines(args[2]);
-        ClassPathValidator validator = new ClassPathValidator(ignorePrefixes, ignoreSuffixes);
+        List<String> includePrefixes = readInputLines(args[3]);
+        List<String> includeSuffixes = readInputLines(args[4]);
+        ClassPathValidator validator = new ClassPathValidator(ignorePrefixes, ignoreSuffixes, includePrefixes, includeSuffixes);
         List<ClasspathValidatorJarInput> jars = labelsToJarsPaths.stream()
                 .map(ClasspathValidatorCli::toInput)
                 .collect(Collectors.toList());
@@ -34,7 +38,6 @@ public class ClasspathValidatorCli {
         if (!collisions.isEmpty()) {
             throw new RuntimeException(exceptionCountPrint);
         }
-
     }
 
     private static List<String> readInputLines(String filePath) throws IOException {

--- a/src/test/com/bazelbuild/java/classpath/BUILD.bazel
+++ b/src/test/com/bazelbuild/java/classpath/BUILD.bazel
@@ -33,3 +33,11 @@ java_test(
         ":classpath",
     ],
 )
+
+java_test(
+    name = "classpathValidatorArguments",
+    test_class = "com.bazelbuild.java.classpath.ClasspathValidatorArgumentsTest",
+    runtime_deps = [
+        ":classpath",
+    ],
+)

--- a/src/test/com/bazelbuild/java/classpath/ClassPathValidatorIT.java
+++ b/src/test/com/bazelbuild/java/classpath/ClassPathValidatorIT.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.bazelbuild.java.classpath.ClassPathValidatorTestingUtils.prepareDummyJarWith;
+import static com.bazelbuild.java.classpath.ClassPathValidatorTestingUtils.setupCollision;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -19,16 +20,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class ClassPathValidatorIT {
 
-    ClassPathValidator validator = new ClassPathValidator(Collections.emptyList(),Collections.emptyList());
+    ClassPathValidator validator = new ClassPathValidator(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
 
     @Test
     public void returnEmptyCollisionIfNoRecordWithSamePathWasFound() throws IOException, NoSuchAlgorithmException {
         DummyFileEntry jarEntryA = new DummyFileEntry("a.txt", "I am A");
         Path dummyJarPathA = prepareDummyJarWith(jarEntryA);
-        ClasspathValidatorJarInput jarInputA = new ClasspathValidatorJarInput("//a",dummyJarPathA);
+        ClasspathValidatorJarInput jarInputA = new ClasspathValidatorJarInput("//a", dummyJarPathA);
+
         DummyFileEntry jarEntryB = new DummyFileEntry("b.txt", "I am B");
         Path dummyJarPathB = prepareDummyJarWith(jarEntryB);
-        ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b",dummyJarPathB);
+        ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b", dummyJarPathB);
 
         List<ClasspathCollision> collisions = validator.collisionsIn(Arrays.asList(jarInputA,jarInputB));
 
@@ -50,17 +52,81 @@ public class ClassPathValidatorIT {
 
     @Test
     public void findCollisionIfSamePathFoundWithDifferentContent() throws IOException, NoSuchAlgorithmException {
-        String samePath = "file.txt";
-        DummyFileEntry jarEntryA = new DummyFileEntry(samePath, "I am A");
-        Path dummyJarPathA = prepareDummyJarWith(jarEntryA);
-        ClasspathValidatorJarInput jarInputA = new ClasspathValidatorJarInput("//a",dummyJarPathA);
-        DummyFileEntry jarEntryB = new DummyFileEntry(samePath, "I am B");
-        Path dummyJarPathB = prepareDummyJarWith(jarEntryB);
-        ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b",dummyJarPathB);
+        List<ClasspathCollision> collisions = validator.collisionsIn(setupCollision("file.txt", "//a", "//b"));
 
-        List<ClasspathCollision> collisions = validator.collisionsIn(Arrays.asList(jarInputA,jarInputB));
-
-        ClasspathCollision expected = new ClasspathCollision(jarInputA.label,jarInputB.label,Arrays.asList(samePath));
+        ClasspathCollision expected = new ClasspathCollision("//a", "//b", Arrays.asList("file.txt"));
         assertThat(collisions).usingFieldByFieldElementComparator().contains(expected);
+    }
+
+    @Test
+    public void ignoreCollisionIfPrefixIsNotIncluded() throws IOException {
+        ClassPathValidator validator = new ClassPathValidator(
+                Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList("not-file.txt"), Collections.emptyList()
+        );
+
+        List<ClasspathCollision> collisions = validator.collisionsIn(setupCollision("file.txt", "//a", "//b"));
+        assertThat(collisions).isEmpty();
+    }
+
+    @Test
+    public void ignoreCollisionIfSuffixIsNotIncluded() throws IOException {
+        ClassPathValidator validator = new ClassPathValidator(
+                Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList(), Arrays.asList(".md")
+        );
+
+        List<ClasspathCollision> collisions = validator.collisionsIn(setupCollision("file.txt", "//a", "//b"));
+        assertThat(collisions).isEmpty();
+    }
+
+    @Test
+    public void collisionsCapturedIfPrefixMatch() throws IOException {
+        ClassPathValidator validator = new ClassPathValidator(
+                Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList("file"), Collections.emptyList()
+        );
+
+        List<ClasspathCollision> collisions = validator.collisionsIn(setupCollision("file.txt", "//a", "//b"));
+        ClasspathCollision expected = new ClasspathCollision("//a", "//b", Arrays.asList("file.txt"));
+
+        assertThat(collisions).usingFieldByFieldElementComparator().contains(expected);
+    }
+
+    @Test
+    public void collisionsCapturedIfSuffixMatch() throws IOException {
+        ClassPathValidator validator = new ClassPathValidator(
+                Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList(), Arrays.asList(".txt")
+        );
+
+        List<ClasspathCollision> collisions = validator.collisionsIn(setupCollision("file.txt", "//a", "//b"));
+        ClasspathCollision expected = new ClasspathCollision("//a", "//b", Arrays.asList("file.txt"));
+
+        assertThat(collisions).usingFieldByFieldElementComparator().contains(expected);
+    }
+
+    @Test
+    public void ignorePrefixesTakePrecendenceOverIncludePrefixes() throws IOException {
+        ClassPathValidator validator = new ClassPathValidator(
+                Arrays.asList("file"), Collections.emptyList(),
+                Arrays.asList("file"), Collections.emptyList()
+        );
+
+        List<ClasspathCollision> collisions = validator.collisionsIn(setupCollision("file.txt", "//a", "//b"));
+
+        assertThat(collisions).isEmpty();
+    }
+
+    @Test
+    public void ignoreSuffixesTakePrecendenceOverIncludeSuffixes() throws IOException {
+        ClassPathValidator validator = new ClassPathValidator(
+                Collections.emptyList(), Arrays.asList(".txt"),
+                Collections.emptyList(), Arrays.asList(".txt")
+        );
+
+        List<ClasspathCollision> collisions = validator.collisionsIn(setupCollision("file.txt", "//a", "//b"));
+
+        assertThat(collisions).isEmpty();
     }
 }

--- a/src/test/com/bazelbuild/java/classpath/ClassPathValidatorTestingUtils.java
+++ b/src/test/com/bazelbuild/java/classpath/ClassPathValidatorTestingUtils.java
@@ -3,11 +3,24 @@ package com.bazelbuild.java.classpath;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
-public class ClassPathValidatorTestingUtils{
+public class ClassPathValidatorTestingUtils {
+    public static List<ClasspathValidatorJarInput> setupCollision(String filePath, String labelA, String labelB) throws IOException {
+        DummyFileEntry jarEntryA = new DummyFileEntry(filePath, "Contents A");
+        Path dummyJarPathA = prepareDummyJarWith(jarEntryA);
+        ClasspathValidatorJarInput jarInputA = new ClasspathValidatorJarInput("//a", dummyJarPathA);
+        DummyFileEntry jarEntryB = new DummyFileEntry(filePath, "Contents B");
+        Path dummyJarPathB = prepareDummyJarWith(jarEntryB);
+        ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b", dummyJarPathB);
+
+        return Arrays.asList(jarInputA, jarInputB);
+    }
+
     public static Path prepareDummyJarWith(DummyFileEntry... entries) throws IOException {
         Path basePath = Files.createTempDirectory("classpath-entries");
         Path jarPath = basePath.resolve("tempJar.jar");

--- a/src/test/com/bazelbuild/java/classpath/ClasspathValidatorArgumentsTest.java
+++ b/src/test/com/bazelbuild/java/classpath/ClasspathValidatorArgumentsTest.java
@@ -1,0 +1,153 @@
+package com.bazelbuild.java.classpath;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public class ClasspathValidatorArgumentsTest {
+
+    @Test
+    public void defaultValuesAreEmpty() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{});
+
+        argsAreEmpty(args);
+    }
+
+    @Test
+    public void ignoresUnrecognisedArgs() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--not-recognised",
+            "123",
+            "--help",
+            "--version",
+        });
+
+        argsAreEmpty(args);
+    }
+
+    @Test
+    public void notSpecifyingValuesIsAllowed() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--ignore-prefix",
+            "--ignore-suffix",
+            "--include-prefix",
+            "--include-suffix",
+        });
+
+        argsAreEmpty(args);
+
+        args = new ClasspathValidatorArguments(new String[]{
+            "--ignore-prefix=",
+            "--ignore-suffix=",
+            "--include-prefix=",
+            "--include-suffix=",
+        });
+
+        argsAreEmpty(args);
+    }
+
+    @Test
+    public void canSetIgnorePrefix() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--ignore-prefix=prefix1",
+            "--ignore-prefix=prefix2",
+            "--ignore-prefix=prefix3",
+        });
+
+        assertThat(args.getIgnorePrefix()).isEqualTo(Arrays.asList("prefix1", "prefix2", "prefix3"));
+        assertThat(args.getIgnoreSuffix()).isEmpty();
+        assertThat(args.getIncludePrefix()).isEmpty();
+        assertThat(args.getIncludeSuffix()).isEmpty();
+        assertThat(args.getJarTargets()).isEmpty();
+    }
+
+    @Test
+    public void canSetIgnoreSuffix() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--ignore-suffix=suffix1",
+            "--ignore-suffix=suffix2",
+            "--ignore-suffix=suffix3",
+        });
+
+        assertThat(args.getIgnorePrefix()).isEmpty();
+        assertThat(args.getIgnoreSuffix()).isEqualTo(Arrays.asList("suffix1", "suffix2", "suffix3"));
+        assertThat(args.getIncludePrefix()).isEmpty();
+        assertThat(args.getIncludeSuffix()).isEmpty();
+        assertThat(args.getJarTargets()).isEmpty();
+    }
+
+    @Test
+    public void canSetIncludePrefix() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--include-prefix=prefix1",
+            "--include-prefix=prefix2",
+            "--include-prefix=prefix3",
+        });
+
+        assertThat(args.getIgnorePrefix()).isEmpty();
+        assertThat(args.getIgnoreSuffix()).isEmpty();
+        assertThat(args.getIncludePrefix()).isEqualTo(Arrays.asList("prefix1", "prefix2", "prefix3"));
+        assertThat(args.getIncludeSuffix()).isEmpty();
+        assertThat(args.getJarTargets()).isEmpty();
+    }
+
+    @Test
+    public void canSetIncludeSuffix() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--include-suffix=suffix1",
+            "--include-suffix=suffix2",
+            "--include-suffix=suffix3",
+        });
+
+        assertThat(args.getIgnorePrefix()).isEmpty();
+        assertThat(args.getIgnoreSuffix()).isEmpty();
+        assertThat(args.getIncludePrefix()).isEmpty();
+        assertThat(args.getIncludeSuffix()).isEqualTo(Arrays.asList("suffix1", "suffix2", "suffix3"));
+        assertThat(args.getJarTargets()).isEmpty();
+    }
+
+    @Test
+    public void canSetJarTargets() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--jar-targets=target1",
+            "--jar-targets=target2",
+            "--jar-targets=target3",
+        });
+
+        assertThat(args.getIgnorePrefix()).isEmpty();
+        assertThat(args.getIgnoreSuffix()).isEmpty();
+        assertThat(args.getIncludePrefix()).isEmpty();
+        assertThat(args.getIncludeSuffix()).isEmpty();
+        assertThat(args.getJarTargets()).isEqualTo(Arrays.asList("target1", "target2", "target3"));
+    }
+
+    @Test
+    public void canSetAllParameters() {
+        ClasspathValidatorArguments args = new ClasspathValidatorArguments(new String[]{
+            "--ignore-prefix=prefix1",
+            "--ignore-suffix=suffix1",
+            "--include-prefix=prefix2",
+            "--include-suffix=suffix2",
+            "--jar-targets=target1",
+        });
+
+        assertThat(args.getIgnorePrefix()).isEqualTo(Arrays.asList("prefix1"));
+        assertThat(args.getIgnoreSuffix()).isEqualTo(Arrays.asList("suffix1"));
+        assertThat(args.getIncludePrefix()).isEqualTo(Arrays.asList("prefix2"));
+        assertThat(args.getIncludeSuffix()).isEqualTo(Arrays.asList("suffix2"));
+        assertThat(args.getJarTargets()).isEqualTo(Arrays.asList("target1"));
+    }
+
+    private void argsAreEmpty(ClasspathValidatorArguments args) {
+        assertThat(args.getIgnorePrefix()).isEmpty();
+        assertThat(args.getIgnoreSuffix()).isEmpty();
+        assertThat(args.getIncludePrefix()).isEmpty();
+        assertThat(args.getIncludeSuffix()).isEmpty();
+        assertThat(args.getJarTargets()).isEmpty();
+    }
+}

--- a/src/test/com/bazelbuild/java/classpath/ClasspathValidatorCliIT.java
+++ b/src/test/com/bazelbuild/java/classpath/ClasspathValidatorCliIT.java
@@ -30,7 +30,13 @@ public class ClasspathValidatorCliIT {
         Path inputFile = prepareInputFileWith(jarInputA,jarInputB);
         Path ignorePrefixFile = Files.createTempFile("ignore_prefix",".txt");
         Path ignoreSuffixFile = Files.createTempFile("ignore_suffix",".txt");
-        String[] args = {inputFile.toString(), ignorePrefixFile.toString(), ignoreSuffixFile.toString()};
+        Path includePrefixFile = Files.createTempFile("include_prefix",".txt");
+        Path includeSuffixFile = Files.createTempFile("inclue_suffix",".txt");
+        String[] args = {
+                inputFile.toString(),
+                ignorePrefixFile.toString(), ignoreSuffixFile.toString(),
+                includePrefixFile.toString(), includeSuffixFile.toString()
+        };
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
         assertThat(thrown).isInstanceOf(RuntimeException.class).hasMessageContaining("1 collisions");
@@ -39,7 +45,7 @@ public class ClasspathValidatorCliIT {
     @Test
     public void throwIllegalArgumentForNonReadableJarsFilePath() throws IOException {
         Path inputFile = Files.createTempDirectory("my-temp").resolve("non-existing.txt");
-        String[] args = {inputFile.toString(), inputFile.toString() ,inputFile.toString()};
+        String[] args = {inputFile.toString(), inputFile.toString(), inputFile.toString(), inputFile.toString(), inputFile.toString()};
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
         assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("is not readable");
@@ -67,7 +73,13 @@ public class ClasspathValidatorCliIT {
         Path inputFile = prepareInputFileWith(jarInputA,jarInputB);
         Path ignorePrefixFile = Files.createTempFile("ignore_prefix",".txt");
         Path ignoreSuffixFile = Files.createTempFile("ignore_suffix",".txt");
-        String[] args = {inputFile.toString(), ignorePrefixFile.toString(), ignoreSuffixFile.toString()};
+        Path includePrefixFile = Files.createTempFile("include_prefix",".txt");
+        Path includeSuffixFile = Files.createTempFile("include_suffix",".txt");
+        String[] args = {
+                inputFile.toString(),
+                ignorePrefixFile.toString(), ignoreSuffixFile.toString(),
+                includePrefixFile.toString(), includeSuffixFile.toString(),
+        };
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
         assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("is not readable");
@@ -82,10 +94,16 @@ public class ClasspathValidatorCliIT {
         Path dummyJarPathB = prepareDummyJarWith(jarEntryB);
         ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b",dummyJarPathB);
 
-        Path inputFile = prepareInputFileWith(jarInputA,jarInputB);
+        Path inputFile = prepareInputFileWith(jarInputA, jarInputB);
         Path ignorePrefixFile = Files.createTempFile("ignore_prefix",".txt");
         Path ignoreSuffixFile = Files.createTempFile("ignore_suffix",".txt");
-        String[] args = {inputFile.toString(), ignorePrefixFile.toString(), ignoreSuffixFile.toString()};
+        Path includePrefixFile = Files.createTempFile("include_prefix",".txt");
+        Path includeSuffixFile = Files.createTempFile("include_suffix",".txt");
+        String[] args = {
+                inputFile.toString(),
+                ignorePrefixFile.toString(), ignoreSuffixFile.toString(),
+                includePrefixFile.toString(), includeSuffixFile.toString(),
+        };
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
         assertThat(thrown).isNull();

--- a/src/test/com/bazelbuild/java/classpath/ClasspathValidatorCliIT.java
+++ b/src/test/com/bazelbuild/java/classpath/ClasspathValidatorCliIT.java
@@ -5,10 +5,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.bazelbuild.java.classpath.ClassPathValidatorTestingUtils.prepareDummyJarWith;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,20 +23,13 @@ public class ClasspathValidatorCliIT {
         DummyFileEntry jarEntryA = new DummyFileEntry(samePath, "I am A");
         Path dummyJarPathA = prepareDummyJarWith(jarEntryA);
         ClasspathValidatorJarInput jarInputA = new ClasspathValidatorJarInput("//a",dummyJarPathA);
+
         DummyFileEntry jarEntryB = new DummyFileEntry(samePath, "I am B");
         Path dummyJarPathB = prepareDummyJarWith(jarEntryB);
         ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b",dummyJarPathB);
 
-        Path inputFile = prepareInputFileWith(jarInputA,jarInputB);
-        Path ignorePrefixFile = Files.createTempFile("ignore_prefix",".txt");
-        Path ignoreSuffixFile = Files.createTempFile("ignore_suffix",".txt");
-        Path includePrefixFile = Files.createTempFile("include_prefix",".txt");
-        Path includeSuffixFile = Files.createTempFile("inclue_suffix",".txt");
-        String[] args = {
-                inputFile.toString(),
-                ignorePrefixFile.toString(), ignoreSuffixFile.toString(),
-                includePrefixFile.toString(), includeSuffixFile.toString()
-        };
+        String[] args = getJarTargetsParameter(jarInputA, jarInputB);
+
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
         assertThat(thrown).isInstanceOf(RuntimeException.class).hasMessageContaining("1 collisions");
@@ -45,18 +38,10 @@ public class ClasspathValidatorCliIT {
     @Test
     public void throwIllegalArgumentForNonReadableJarsFilePath() throws IOException {
         Path inputFile = Files.createTempDirectory("my-temp").resolve("non-existing.txt");
-        String[] args = {inputFile.toString(), inputFile.toString(), inputFile.toString(), inputFile.toString(), inputFile.toString()};
+        String[] args = {"--jar-targets=" + inputFile.toString()};
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("is not readable");
-    }
-
-    @Test
-    public void throwIllegalArgumentForMissingArguments() throws IOException {
-        String[] args = {};
-        Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
-
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Usage: ");
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Illegal line in jars file");
     }
 
     @Test
@@ -70,16 +55,7 @@ public class ClasspathValidatorCliIT {
         Files.delete(dummyJarPathB);
         ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b",dummyJarPathB);
 
-        Path inputFile = prepareInputFileWith(jarInputA,jarInputB);
-        Path ignorePrefixFile = Files.createTempFile("ignore_prefix",".txt");
-        Path ignoreSuffixFile = Files.createTempFile("ignore_suffix",".txt");
-        Path includePrefixFile = Files.createTempFile("include_prefix",".txt");
-        Path includeSuffixFile = Files.createTempFile("include_suffix",".txt");
-        String[] args = {
-                inputFile.toString(),
-                ignorePrefixFile.toString(), ignoreSuffixFile.toString(),
-                includePrefixFile.toString(), includeSuffixFile.toString(),
-        };
+        String[] args = getJarTargetsParameter(jarInputA, jarInputB);
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
         assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("is not readable");
@@ -94,27 +70,19 @@ public class ClasspathValidatorCliIT {
         Path dummyJarPathB = prepareDummyJarWith(jarEntryB);
         ClasspathValidatorJarInput jarInputB = new ClasspathValidatorJarInput("//b",dummyJarPathB);
 
-        Path inputFile = prepareInputFileWith(jarInputA, jarInputB);
-        Path ignorePrefixFile = Files.createTempFile("ignore_prefix",".txt");
-        Path ignoreSuffixFile = Files.createTempFile("ignore_suffix",".txt");
-        Path includePrefixFile = Files.createTempFile("include_prefix",".txt");
-        Path includeSuffixFile = Files.createTempFile("include_suffix",".txt");
-        String[] args = {
-                inputFile.toString(),
-                ignorePrefixFile.toString(), ignoreSuffixFile.toString(),
-                includePrefixFile.toString(), includeSuffixFile.toString(),
-        };
+        String[] args = getJarTargetsParameter(jarInputA, jarInputB);
         Throwable thrown = catchThrowable(() -> ClasspathValidatorCli.main(args));
 
         assertThat(thrown).isNull();
     }
 
-    private Path prepareInputFileWith(ClasspathValidatorJarInput... jarsInput) throws IOException {
-        Path inputFile = Files.createTempFile("jarFiles",".txt");
-        for(ClasspathValidatorJarInput input:jarsInput){
-            String line = String.format("%s %s\n", input.label,input.jarPath.toString());
-            Files.write(inputFile,line.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+    private String[] getJarTargetsParameter(ClasspathValidatorJarInput ...jarInputs) {
+        List<String> args = new ArrayList<>();
+
+        for (ClasspathValidatorJarInput jarInput: jarInputs) {
+            args.add(String.format("--jar-targets=%s %s", jarInput.label, jarInput.jarPath.toString()));
         }
-        return inputFile;
+
+        return args.toArray(new String[args.size()]);
     }
 }


### PR DESCRIPTION
Add `include_prefixes` and `include_suffixes` to `classpath_collision_test` which act as the inverse of `ignore_prefixes` and `ignore_suffixes`. 

Originally, I wanted to make it so that `include_` and `ignore_` parameters are mutually exclusive, i.e. they cannot be provided together, but due to default ignore lists, this was not possible. Instead both `include_` and `ignore_` parameters can be specified
and if there's an entry in a JAR that matches both, `ignore_` will take precedence, i.e. it will not be included.