### PR TITLE
Fixed Cirrus Config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,34 +1,33 @@
-bazel_build:
+container:
+  image: l.gcr.io/google/bazel:3.0.0
+
+environment:
+  XDG_CACHE_HOME: /xdg_cache
+
+task:
   name: test
-  container:
-    image: l.gcr.io/google/bazel:3.0.0
+  bazelisk_installation_script:
+    - |
+      rm /usr/local/bin/bazel
+      curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64"
+      mv bazelisk-linux-amd64 "/usr/bin/bazel"
+      chmod +x /usr/bin/bazel
+      which bazel
 
-  environment:
-    XDG_CACHE_HOME: /xdg_cache
+  bazelisk_cache:
+    folder: $XDG_CACHE_HOME
+    fingerprint_script: cat .bazelversion
+    populate_script: mkdir -p $XDG_CACHE_HOME && bazel version
 
-  task:
-    bazelisk_installation_script:
-      - |
-        rm /usr/local/bin/bazel
-        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64"
-        mv bazelisk-linux-amd64 "/usr/bin/bazel"
-        chmod +x /usr/bin/bazel
-        which bazel
+  bazel_repository_cache:
+    folder: /.repo_cache
+    fingerprint_script: cat WORKSPACE
+    populate_script: mkdir -p /.repo_cache && bazel fetch --repository_cache=/.repo_cache //...
 
-    bazelisk_cache:
-      folder: $XDG_CACHE_HOME
-      fingerprint_script: cat .bazelversion
-      populate_script: mkdir -p $XDG_CACHE_HOME && bazel version
+  test_script:
+    - bazel test --repository_cache=/.repo_cache -k --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST //...
 
-    bazel_repository_cache:
-      folder: /.repo_cache
-      fingerprint_script: cat WORKSPACE
-      populate_script: mkdir -p /.repo_cache && bazel fetch --repository_cache=/.repo_cache //...
-
-    test_script:
-      - bazel test --repository_cache=/.repo_cache -k --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST //...
-
-    always:
-      junit_result_artifacts:
-        path: "bazel-testlogs/**/test.xml"
-        format: junit
+  always:
+    junit_result_artifacts:
+      path: "bazel-testlogs/**/test.xml"
+      format: junit


### PR DESCRIPTION
Your config was parsed before just by accident because of a not that strict of a parser. We are migrating to a [new parser written in Go](https://github.com/cirruslabs/cirrus-cli/tree/master/pkg/parser) which won't parse the config.