### PR TITLE
Go back to using files to pass jar targets

### DIFF
--- a/src/main/com/bazelbuild/java/classpath/ClasspathValidatorArguments.java
+++ b/src/main/com/bazelbuild/java/classpath/ClasspathValidatorArguments.java
@@ -9,7 +9,7 @@ public class ClasspathValidatorArguments {
     private List<String> ignoreSuffix = new ArrayList<>();
     private List<String> includePrefix = new ArrayList<>();
     private List<String> includeSuffix = new ArrayList<>();
-    private List<String> jarTargets = new ArrayList<>();
+    private String jarTargets;
 
     final private String JarTargets = "--jar-targets";
     final private String IgnorePrefix = "--ignore-prefix";
@@ -17,14 +17,17 @@ public class ClasspathValidatorArguments {
     final private String IncludePrefix = "--include-prefix";
     final private String IncludeSuffix = "--include-suffix";
 
-    final private List<String> Arguments = Arrays.asList(
-        JarTargets, IgnorePrefix, IgnoreSuffix, IncludePrefix, IncludeSuffix
-    );
 
     public ClasspathValidatorArguments(String[] args) {
         List<String> arguments = Arrays.asList(args);
 
-        jarTargets = extractParameters(JarTargets, arguments);
+        List<String> jarTargetsArgs = extractParameters(JarTargets, arguments);
+
+        if (jarTargetsArgs.size() != 1) {
+            throw new IllegalArgumentException(String.format("'%s' must be specified exactly once", JarTargets));
+        }
+        jarTargets = jarTargetsArgs.get(0);
+
         ignorePrefix = extractParameters(IgnorePrefix, arguments);
         ignoreSuffix = extractParameters(IgnoreSuffix, arguments);
         includePrefix = extractParameters(IncludePrefix, arguments);
@@ -63,7 +66,7 @@ public class ClasspathValidatorArguments {
         return includeSuffix;
     }
 
-    public List<String> getJarTargets() {
+    public String getJarTargets() {
         return jarTargets;
     }
 }

--- a/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
+++ b/src/main/com/bazelbuild/java/classpath/ClasspathValidatorCli.java
@@ -15,7 +15,9 @@ public class ClasspathValidatorCli {
 
         ClasspathValidatorArguments cliArgs = new ClasspathValidatorArguments(args);
 
-        List<String> labelsToJarsPaths = cliArgs.getJarTargets();
+        String labelsToJarsPathsFile = cliArgs.getJarTargets();
+        List<String> labelsToJarsPaths = readInputLines(labelsToJarsPathsFile);
+
         List<String> ignorePrefixes = cliArgs.getIgnorePrefix();
         List<String> ignoreSuffixes = cliArgs.getIgnoreSuffix();
         List<String> includePrefixes = cliArgs.getIncludePrefix();
@@ -65,5 +67,14 @@ public class ClasspathValidatorCli {
             throw new IllegalArgumentException(error);
         }
         return path;
+    }
+
+    private static List<String> readInputLines(String filePath) throws IOException {
+        Path targetsToJarsFile = asReadablePath(filePath);
+        return Files.readAllLines(targetsToJarsFile).stream()
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .filter(s -> !s.startsWith("#"))
+            .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Go back to passing JAR targets via a file, because a very large number of CLI arguments
would hit limits imposed by operating system (Mac OS seems to be impacted the most).